### PR TITLE
feat(upgrade): upgrade to NixOS 25.11 unstable and improve configuration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -130,11 +130,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1758108966,
-        "narHash": "sha256-ytw7ROXaWZ7OfwHrQ9xvjpUWeGVm86pwnEd1QhzawIo=",
+        "lastModified": 1759523803,
+        "narHash": "sha256-PTod9NG+i3XbbnBKMl/e5uHDBYpwIWivQ3gOWSEuIEM=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "54df955a695a84cd47d4a43e08e1feaf90b1fd9b",
+        "rev": "cfc9f7bb163ad8542029d303e599c0f7eee09835",
         "type": "github"
       },
       "original": {
@@ -216,11 +216,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759337100,
-        "narHash": "sha256-CcT3QvZ74NGfM+lSOILcCEeU+SnqXRvl1XCRHenZ0Us=",
+        "lastModified": 1759536080,
+        "narHash": "sha256-0aXlKPxm2M+F5oywX2TTbY0e6h+tQ+6OYyx7UZn3A4A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "004753ae6b04c4b18aa07192c1106800aaacf6c3",
+        "rev": "edafd6da1936426708f1be0b1a4288007f16639a",
         "type": "github"
       },
       "original": {
@@ -319,11 +319,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758029226,
-        "narHash": "sha256-TjqVmbpoCqWywY9xIZLTf6ANFvDCXdctCjoYuYPYdMI=",
+        "lastModified": 1759070547,
+        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "08b8f92ac6354983f5382124fef6006cade4a1c1",
+        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
         "type": "github"
       },
       "original": {
@@ -345,22 +345,6 @@
       "original": {
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1759281824,
-        "narHash": "sha256-FIBE1qXv9TKvSNwst6FumyHwCRH3BlWDpfsnqRDCll0=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "5b5be50345d4113d04ba58c444348849f5585b4a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.05",
-        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -491,7 +475,6 @@
         "nixos-wsl": "nixos-wsl",
         "nixowos": "nixowos",
         "nixpkgs": "nixpkgs_5",
-        "nixpkgs-stable": "nixpkgs-stable",
         "sops-nix": "sops-nix",
         "systems": "systems",
         "treefmt-nix": "treefmt-nix",

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,6 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-25.05";
     nixos-wsl.url = "github:nix-community/NixOS-WSL/main";
     home-manager = {
       url = "github:nix-community/home-manager";
@@ -33,7 +32,6 @@
   outputs =
     {
       nixpkgs,
-      nixpkgs-stable,
       systems,
       home-manager,
       nixos-wsl,
@@ -78,7 +76,7 @@
 
           fuyidong = import ./nix/fuyidong.nix {
             inherit
-              nixpkgs-stable
+              nixpkgs
               sops-nix
               nixowos
               home-manager

--- a/hosts/fuyidong/boot.nix
+++ b/hosts/fuyidong/boot.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 
 {
 
@@ -10,6 +10,8 @@
       };
       efi.canTouchEfiVariables = true;
     };
+
+    kernelModules = lib.mkAfter [ "coretemp" ];
 
     kernel.sysctl = {
       "kernel.panic" = 10;

--- a/hosts/fuyidong/configuration.nix
+++ b/hosts/fuyidong/configuration.nix
@@ -15,7 +15,7 @@
     ../../users/users.nix
   ];
 
-  system.stateVersion = "25.05";
+  system.stateVersion = "25.11";
 
   programs.nix-ld.enable = true;
 
@@ -23,10 +23,13 @@
     allowUnfree = true;
   };
 
-  nix.settings.experimental-features = [
-    "nix-command"
-    "flakes"
-  ];
+  nix.settings = {
+    experimental-features = [
+      "nix-command"
+      "flakes"
+    ];
+    download-buffer-size = 1073741824;
+  };
 
   nixowos.enable = true;
 

--- a/modules/desktop.nix
+++ b/modules/desktop.nix
@@ -5,10 +5,10 @@
   networking.networkmanager.enable = true;
 
   programs.xwayland.enable = true;
-  services.xserver.enable = true;
+  # services.xserver.enable = true;
 
-  services.xserver.displayManager.gdm.enable = true;
-  services.xserver.desktopManager.gnome = {
+  services.displayManager.gdm.enable = true;
+  services.desktopManager.gnome = {
     enable = true;
     extraGSettingsOverrides = ''
       [org.gnome.mutter]

--- a/modules/services/battery.nix
+++ b/modules/services/battery.nix
@@ -14,7 +14,7 @@ _: {
       CPU_MIN_PERF_ON_AC = 0;
       CPU_MAX_PERF_ON_AC = 100;
       CPU_MIN_PERF_ON_BAT = 0;
-      CPU_MAX_PERF_ON_BAT = 20;
+      CPU_MAX_PERF_ON_BAT = 25;
 
       CPU_BOOST_ON_AC = 1;
       CPU_BOOST_ON_BAT = 0;
@@ -24,6 +24,12 @@ _: {
 
       START_CHARGE_THRESH_BAT0 = 70;
       STOP_CHARGE_THRESH_BAT0 = 81;
+
+      CPU_SCALING_DRIVER_ON_AC = "intel_pstate";
+      CPU_SCALING_DRIVER_ON_BAT = "intel_pstate";
+
+      WIFI_PWR_ON_AC = "off";
+      WIFI_PWR_ON_BAT = "on";
     };
   };
 }

--- a/nix/fuyidong.nix
+++ b/nix/fuyidong.nix
@@ -1,5 +1,5 @@
 {
-  nixpkgs-stable,
+  nixpkgs,
   sops-nix,
   nixowos,
   home-manager,
@@ -8,7 +8,7 @@
   ...
 }:
 
-nixpkgs-stable.lib.nixosSystem {
+nixpkgs.lib.nixosSystem {
   system = "x86_64-linux";
   specialArgs = { inherit inputs; };
   modules = [

--- a/users/home-workd.nix
+++ b/users/home-workd.nix
@@ -6,7 +6,7 @@
   home.username = "workd";
   home.homeDirectory = "/home/workd";
 
-  home.stateVersion = "25.05";
+  home.stateVersion = "25.11";
 
   # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;


### PR DESCRIPTION
- Remove nixpkgs-stable input, use unified nixpkgs unstable
- Update fuyidong system to use nixpkgs instead of nixpkgs-stable
- Bump system.stateVersion and home.stateVersion to 25.11
- Update display manager configuration for new NixOS structure
- Add coretemp kernel module and improve nix settings
- Enhance TLP battery configuration with additional settings
- Update flake.lock with latest package versions
